### PR TITLE
Sets travis config to notify only on build state change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ r:
 
 warnings_are_errors: true
 
-
 notifications:
-    slack: newstat:ZqBL05R4NoRMqPZXnuzbF4OZ
-      on_success: change
+  slack:
+    rooms:
+      - newstat:ZqBL05R4NoRMqPZXnuzbF4OZ
+    on_success: change # default: always
+    on_failure: always # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ warnings_are_errors: true
 
 
 notifications:
-    slack: newstat:ZqBL05R4NoRMqPZXnuzbF4OZ
+    slack: 
+      newstat:ZqBL05R4NoRMqPZXnuzbF4OZ
+      on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ warnings_are_errors: true
 
 
 notifications:
-    slack: 
-      newstat:ZqBL05R4NoRMqPZXnuzbF4OZ
+    slack: newstat:ZqBL05R4NoRMqPZXnuzbF4OZ
       on_success: change


### PR DESCRIPTION
Sets travis config to notify only on build state change. More info here:
https://docs.travis-ci.com/user/notifications/#Changing-notification-frequency